### PR TITLE
updated the onboard endpoint logic and template file for IAM roles & …

### DIFF
--- a/onboard/app.py
+++ b/onboard/app.py
@@ -1,7 +1,7 @@
 import json
 import random
 import boto3
-from focus_utils import CORS_HEADERS, USER_TABLE_NAME, check_query_parameters, check_id, get_current_datetime_str, update_last_active_time
+from focus_utils import CORS_HEADERS, USER_TABLE_NAME, check_query_parameters, check_id, get_current_datetime_str, update_last_active_time, generate_weekly_stage_start_times, generate_verification_code
 
 
 def lambda_handler(event, context):
@@ -27,13 +27,12 @@ def lambda_handler(event, context):
     """
 
     # check to see if query parameters have been sent
-    missing_parameters_message = check_query_parameters(event["queryStringParameters"], ["id", "regular_categories", "focusmode_categories"])
+    missing_parameters_message = check_query_parameters(event["queryStringParameters"], ["id", "focusmode_categories"])
     if missing_parameters_message:
         return missing_parameters_message
     
     # get query parameters
     id: str = event["queryStringParameters"]["id"]
-    regular_categories: list[str] = event["queryStringParameters"]["regular_categories"].split(";")
     focusmode_categories: list[str] = event["queryStringParameters"]["focusmode_categories"].split(";")
     
     # check to see if the Prolific ID is valid
@@ -50,41 +49,65 @@ def lambda_handler(event, context):
     # if user exists
     if 'Item' in user_item:
         update_last_active_time(id)
+
+        # only update a focus mode categories
+        response = user_table.update_item(
+                Key={"User_Id": id},
+                UpdateExpression="SET FocusMode_Categories = :focusmode_categories",
+                ExpressionAttributeValues={
+                    ":focusmode_categories": focusmode_categories
+                },
+                ReturnValues="ALL_NEW"
+            )
+        response = response["Attributes"]
+        data = {
+            "user_Id": str(response.get("User_Id")),
+            "current_stage": int(response.get("Current_Stage")),
+            "verification_code": str(response.get("Verification_Code")),
+            "is_stage_changed": False,
+            "is_study_completed": False
+        }
         return {
             "statusCode": 400,
             "headers": CORS_HEADERS,
             "body": json.dumps({
-                "message": "User has already onboarded"
+                "data": data, 
+                "message": "User has already onboarded."
             }),
         }
     else:
         # item does not exist -> user has not onboarded before
         # randomly generate order of stage
-        stage_order = list(range(1, 4))
+        stage_order = list(range(1, 5))
         random.shuffle(stage_order)
-
         current_timestamp = get_current_datetime_str()
+        verification_code = generate_verification_code(id)
         # add participant to the user database
         user_table.put_item(
             Item={
                     "User_Id": id,
                     "Stage_Order_List": stage_order,
+                    "Verification_Code": verification_code,
                     "Last_Active_At_Time": current_timestamp,
-                    # start at first stage
-                    "Stage_Id_List": [{
-                        "Stage_Number": stage_order[0],
-                        "Current_Day": 1,
-                        "Stage_Days_Start_Time": [current_timestamp]
-                    }],
-                    "Regular_Categories": regular_categories,
+                    "Stage_Start_Times" : generate_weekly_stage_start_times(current_timestamp, stage_order),
+                    "User_Completed_Stages": [],
+                    "Current_Stage": stage_order[0],
                     "FocusMode_Categories": focusmode_categories
                 }
             )
         
+        data = {
+            "user_Id": id,
+            "current_stage": stage_order[0],
+            "verification_code": verification_code,
+            "is_stage_changed": True,
+            "is_study_completed": False,
+        }
         return {
             "statusCode": 200,
             "headers": CORS_HEADERS,
-            "body": json.dumps(
-                "Received"
-            ),
+            "body": json.dumps({
+                "data": data, 
+                "message": "User onboarded successfully"
+            }),
         }

--- a/template.yaml
+++ b/template.yaml
@@ -67,7 +67,7 @@ Resources:
           Properties:
             RestApiId: !Ref FocusModeApiGateway
             Path: /categorize
-            Method: GET
+            Method: ANY
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref FocusModeUserTable
@@ -92,7 +92,7 @@ Resources:
           Properties:
             RestApiId: !Ref FocusModeApiGateway
             Path: /collect
-            Method: POST
+            Method: ANY
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref FocusModeUserTable
@@ -117,9 +117,11 @@ Resources:
           Properties:
             RestApiId: !Ref FocusModeApiGateway
             Path: /onboard
-            Method: GET
+            Method: ANY
       Policies:
         - DynamoDBWritePolicy:
+            TableName: !Ref FocusModeUserTable
+        - DynamoDBReadPolicy:
             TableName: !Ref FocusModeUserTable
         - DynamoDBReadPolicy:
             TableName: !Ref FocusModeAdminTable
@@ -140,9 +142,11 @@ Resources:
           Properties:
             RestApiId: !Ref FocusModeApiGateway
             Path: /stage
-            Method: GET
+            Method: ANY
       Policies:
         - DynamoDBWritePolicy:
+            TableName: !Ref FocusModeUserTable
+        - DynamoDBReadPolicy:
             TableName: !Ref FocusModeUserTable
         - DynamoDBReadPolicy:
             TableName: !Ref FocusModeDataCollectionTable


### PR DESCRIPTION
1. Previously, stage progression was tied to user activity — each new stage started 7 days after the user's last active timestamp. This allowed variable-length stages depending on user engagement.

This update decouples stage transitions from user activity. Now, each stage starts exactly 7 days after the previous one, based on the original onboarding/start time. This ensures fixed 7-day durations per stage, regardless of whether the user is active or not.

Updated the stage timing generation logic and comparison checks accordingly.

2. Updated the template file with assignment of additional role and policies to endpoints.