### PR TITLE
updated template file to create video record log APIs and create DynamoDB table 

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -32,6 +32,7 @@ Globals:
         PostStageSurveyDataTableName: !Ref FocusModePostStageSurveyResponseTable
         PostStudySurveyDataTableName: !Ref FocusModePostStudySurveyResponseTable
         UserPreferenceDataTableName: !Ref FocusModeUserPreferenceDataTable
+        VideoRecordLogTableName: !Ref FocusModeVideoRecordLogTable
         AdminTableName: !Ref FocusModeAdminTable
   Api:
     Cors:
@@ -59,6 +60,60 @@ Resources:
     Metadata:
       BuildMethod: python3.12
 
+  VideoRecordLogFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: videoRecordLog/
+      Handler: app.lambda_handler
+      Runtime: python3.12
+      Timeout: 5
+      Architectures:
+        - x86_64
+      Layers:
+        - !Ref UtilsLayer
+      Events:
+        CategorizeApi:
+          Type: Api
+          Properties:
+            RestApiId: !Ref FocusModeApiGateway
+            Path: /videoRecordLog
+            Method: ANY
+      Policies:
+        - DynamoDBReadPolicy:
+            TableName: !Ref FocusModeUserTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref FocusModeVideoRecordLogTable
+        - DynamoDBWritePolicy:
+            TableName: !Ref FocusModeVideoRecordLogTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref FocusModeAdminTable
+
+
+  UpdateWatchTimeFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: updateWatchTime/
+      Handler: app.lambda_handler
+      Runtime: python3.12
+      Timeout: 5
+      Architectures:
+        - x86_64
+      Layers:
+        - !Ref UtilsLayer
+      Events:
+        CategorizeApi:
+          Type: Api
+          Properties:
+            RestApiId: !Ref FocusModeApiGateway
+            Path: /updateWatchTime
+            Method: ANY
+      Policies:
+        - DynamoDBReadPolicy:
+            TableName: !Ref FocusModeUserTable
+        - DynamoDBWritePolicy:
+            TableName: !Ref FocusModeUserTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref FocusModeAdminTable
   CategorizeFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -278,6 +333,25 @@ Resources:
         ReadCapacityUnits: 5
         WriteCapacityUnits: 5
 
+
+  FocusModeVideoRecordLogTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      KeySchema:
+        - AttributeName: prolificId
+          KeyType: HASH
+        - AttributeName: Id
+          KeyType: RANGE
+      AttributeDefinitions:
+        - AttributeName: prolificId
+          AttributeType: S
+        - AttributeName: Id
+          AttributeType: S
+      BillingMode: PROVISIONED
+      ProvisionedThroughput:
+        ReadCapacityUnits: 5
+        WriteCapacityUnits: 5
+        
   FocusModeAdminTable:
     Type: AWS::Serverless::SimpleTable
 


### PR DESCRIPTION
1. Added new API endpoints : 
- Endpoint to store video record logs for each user (prolificId) when videos are created.
- Endpoint to update stage information (e.g., watch time for stage) for existing users.

2. Created a new DynamoDB table: 
- Table to persist video record data, supporting multiple records per user.
- Configured with prolificId as the partition key and Id as the sort key to allow efficient retrieval and updates.